### PR TITLE
Remove duplicate "part" in GetByMXID

### DIFF
--- a/database/message.go
+++ b/database/message.go
@@ -59,7 +59,7 @@ func (mq *MessageQuery) GetByGUID(chat string, guid string, part int) *Message {
 }
 
 func (mq *MessageQuery) GetByMXID(mxid id.EventID) *Message {
-	return mq.get("SELECT chat_guid, guid, part, part, mxid, sender_guid, timestamp "+
+	return mq.get("SELECT chat_guid, guid, part, mxid, sender_guid, timestamp "+
 		"FROM message WHERE mxid=$1", mxid)
 }
 


### PR DESCRIPTION
Fixes:
```
[Jul 27, 2021 17:08:06] [Database/Message/ERROR] Database scan failed: sql: expected 7 destination arguments in Scan, not 6
```