### PR TITLE
Don't debug when a logging payload is received

### DIFF
--- a/ipc/ipc.go
+++ b/ipc/ipc.go
@@ -120,7 +120,11 @@ func (ipc *Processor) Loop() {
 			snip = ""
 			maxLength = len(msg.Data)
 		}
-		ipc.log.Debugfln("Received IPC command: %s/%d - %s%s", msg.Command, msg.ID, msg.Data[:maxLength], snip)
+
+		if msg.Command != "log" {
+			ipc.log.Debugfln("Received IPC command: %s/%d - %s%s", msg.Command, msg.ID, msg.Data[:maxLength], snip)
+		}
+
 		if msg.Command == "response" || msg.Command == "error" {
 			ipc.waiterLock.Lock()
 			waiter, ok := ipc.waiters[msg.ID]


### PR DESCRIPTION
Makes logging output cleaner, since previously it logs everything twice, one as the json payload and the other as a regular logging message