### PR TITLE
Use ~/Library/Messages as tmp on mac-nosip

### DIFF
--- a/imessage/mac-nosip/nosip.go
+++ b/imessage/mac-nosip/nosip.go
@@ -49,7 +49,7 @@ func NewMacNoSIPConnector(bridge imessage.Bridge) (imessage.API, error) {
 	logger := bridge.GetLog().Sub("iMessage").Sub("Mac-noSIP")
 	processLogger := bridge.GetLog().Sub("iMessage").Sub("Barcelona")
 	return &MacNoSIPConnector{
-		APIWithIPC: ios.NewPlainiOSConnector(logger, false),
+		APIWithIPC: ios.NewPlainiOSConnector(logger, false, true),
 		path:       bridge.GetConnectorConfig().IMRestPath,
 		log:        logger,
 		procLog:    processLogger,

--- a/imessage/struct.go
+++ b/imessage/struct.go
@@ -212,4 +212,5 @@ type ConnectorCapabilities struct {
 	SendTapbacks            bool
 	SendReadReceipts        bool
 	SendTypingNotifications bool
+	SandboxedTempDirectory  bool
 }


### PR DESCRIPTION
imagent on newer versions of big sur has difficult reading /tmp/mautrix-imessage<tmpcode> due to tightened sandbox profiles. when on mac-nosip, this PR has mautrix-imessage use ~/Library/Messages/mautrix-imessage<tmpcode> instead.